### PR TITLE
Axios transpiler mapping fix

### DIFF
--- a/jest.base.config.js
+++ b/jest.base.config.js
@@ -28,8 +28,8 @@ module.exports = {
       : '<rootDir>/test/**/*.test.ts'
   ],
   moduleNameMapper: {
-    "^axios$": "axios",
-  },  
+    axios: "axios/dist/node/axios.cjs"
+  },
   testRunner: "jest-circus/runner",
   collectCoverage: true,
   coverageReporters: ['json', 'lcov', 'text', 'clover', 'json-summary'],


### PR DESCRIPTION
Axios version 1+ is using **ECMA** script. Added module mapping so the jest transpiler will know how to import the module correctly.